### PR TITLE
Fixes #83 - Adjust search bar padding in Courses tab

### DIFF
--- a/components/pages/CoursesPage.tsx
+++ b/components/pages/CoursesPage.tsx
@@ -278,8 +278,8 @@ const CoursesPage: React.FC = () => {
         </RevealOnScroll>
 
         <RevealOnScroll direction="up" delay={300} duration={800}>
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 mb-8 backdrop-blur-sm bg-opacity-95 dark:bg-opacity-95">
-            <div className="flex items-center gap-3 mb-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-2 mb-8 backdrop-blur-sm bg-opacity-95 dark:bg-opacity-95">
+            <div className="flex items-center gap-3 p-2">
               <div className="flex-1 relative">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
                 <input


### PR DESCRIPTION
This PR fixes the improper padding in the search bar of the Courses tab to ensure consistent spacing and improved UI alignment.

Before -
<img width="1914" height="832" alt="Screenshot 2025-07-25 172800" src="https://github.com/user-attachments/assets/bd5d9501-ae93-437a-89bc-b0cd1acf293b" />

After fixing -
<img width="1919" height="825" alt="Screenshot 2025-08-15 021321" src="https://github.com/user-attachments/assets/9abbac2e-e4a7-47cd-9ac6-ed6793173c11" />
